### PR TITLE
Fix for SHA-1 is a Weak Hash Function

### DIFF
--- a/sonar-integration-test/WebGoat-Lessons/http-only/src/main/java/org/owasp/webgoat/plugin/HttpOnly.java
+++ b/sonar-integration-test/WebGoat-Lessons/http-only/src/main/java/org/owasp/webgoat/plugin/HttpOnly.java
@@ -183,7 +183,7 @@ public class HttpOnly extends LessonAdapter
 
         try
         {
-            md = MessageDigest.getInstance("SHA");
+            md = MessageDigest.getInstance("SHA-256");
             buffer = new Date().toString().getBytes();
 
             md.update(buffer);


### PR DESCRIPTION
SHA-1 previously replaced weaker hashing algorithms such as MD1/2/5 however as of August 5, 2015, NIST has recommended that all federal agencies stop using SHA-1 for digital signatures, timestamps and other applications that require collision resistance. Other major vendors such as Microsoft, Google, Mozilla, and Apple have also followed suit. Evidence of this deprecation can be found within the IETF draft, [Deprecating MD5 and SHA1 in TLS 1.2](https://tools.ietf.org/id/draft-lvelvindron-tls-md5-sha1-deprecate-01.html), which leverages the guidelines of [RFC 7525](https://tools.ietf.org/html/rfc7525) recommending only SHA-256 or -384 be used.


